### PR TITLE
Ajuste nos contadores das páginas

### DIFF
--- a/classes/schools/Module.class.php
+++ b/classes/schools/Module.class.php
@@ -8,6 +8,7 @@ class Module
     public string $name;
     public string $createdAt;
     public string $updatedAt;
+    public array $resultBuildList;
 
     //getters and setters
     public function getId(): int
@@ -46,6 +47,14 @@ class Module
         $this->updatedAt = $updatedAt;
     }
     //----------------------------
+    public function getResultBuildList(): array
+    {
+        return $this->resultBuildList;
+    }
+    public function setResultBuildList(array $resultBuildList): void
+    {
+        $this->resultBuildList = $resultBuildList;
+    }
     //----------------------------
     //methods
     /**
@@ -183,6 +192,35 @@ class Module
             array_push($modules, $module);
         }
 
+        $this->setResultBuildList($modules);
         return $modules;
+    }
+
+    //----------------------------
+    /**
+     * @method countTeachers() count the teachers by 
+     * @param string $search 
+     */
+    public function countModules(string $search = ''): string
+    {
+        $searching = (!is_null($search) && !empty($search));
+
+        if ($searching) {
+            $resultBuildList = $this->getResultBuildList();
+            $totalSearch = count($resultBuildList);
+            return "Resultado da pesquisa " . $totalSearch;
+        }
+
+        $connection = Connection::connection();
+        try {
+            $stmt = $connection->prepare("SELECT COUNT(id) AS total FROM teachers");
+            $stmt->execute();
+
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            return "Total " . $result[0]['total'];
+        } catch (Exception $e) {
+            echo $e->getMessage();
+        }
     }
 }

--- a/classes/schools/Module.class.php
+++ b/classes/schools/Module.class.php
@@ -213,7 +213,7 @@ class Module
 
         $connection = Connection::connection();
         try {
-            $stmt = $connection->prepare("SELECT COUNT(id) AS total FROM teachers");
+            $stmt = $connection->prepare("SELECT COUNT(id) AS total FROM modules");
             $stmt->execute();
 
             $result = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/classes/schools/Teacher.class.php
+++ b/classes/schools/Teacher.class.php
@@ -8,6 +8,7 @@ class Teacher
     public string $photo;
     public string $createdAt;
     public string $updatedAt;
+    public array $resultBuildList;
 
     //getters and setters
     public function getId(): int
@@ -55,6 +56,15 @@ class Teacher
         $this->updatedAt = $updatedAt;
     }
     //----------------------------
+    public function getResultBuildList(): array
+    {
+        return $this->resultBuildList;
+    }
+    public function setResultBuildList(array $resultBuildList): void
+    {
+        $this->resultBuildList = $resultBuildList;
+    }
+    //----------------------------
     //methods
     /**
      * @method registerTeacher() registers the teachers by 
@@ -78,7 +88,7 @@ class Teacher
             echo $e->getMessage();
         }
     }
-    
+
     //----------------------------
     /**
      * @method listTeacher() lists the teacher by 
@@ -197,6 +207,35 @@ class Teacher
             array_push($teachers, $teacher);
         }
 
+        $this->setResultBuildList($teachers);
         return $teachers;
+    }
+
+    //----------------------------
+    /**
+     * @method countTeachers() count the teachers by 
+     * @param string $search 
+     */
+    public function countTeachers(string $search = ''): string
+    {
+        $searching = (!is_null($search) && !empty($search));
+
+        if ($searching) {
+            $resultBuildList = $this->getResultBuildList();
+            $totalSearch = count($resultBuildList);
+            return "Resultado da pesquisa " . $totalSearch;
+        }
+
+        $connection = Connection::connection();
+        try {
+            $stmt = $connection->prepare("SELECT COUNT(id) AS total FROM teachers");
+            $stmt->execute();
+
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            return "Total " . $result[0]['total'];
+        } catch (Exception $e) {
+            echo $e->getMessage();
+        }
     }
 }

--- a/private/adm/pages/register/register-module/list-module.page.php
+++ b/private/adm/pages/register/register-module/list-module.page.php
@@ -7,7 +7,9 @@ session_start();
 try {
     $search = $_GET['searchModule'] ?? '';
     $module = new Module();
+
     $listModules = $module->listModule($search);
+    $countModules = $module->countModules($search);
 
     $optionOfSearch = array();
     foreach ($listModules as $row) {
@@ -72,8 +74,7 @@ try {
 
     <!-- Contador de módulos ⬇️ -->
     <p>
-        Total
-        <?php echo count($listModules); ?>
+        <?php echo $countModules ?>
     </p>
 
     <!-- Lista de módulos ⬇️ -->

--- a/private/adm/pages/register/register-teacher/list-teacher.page.php
+++ b/private/adm/pages/register/register-teacher/list-teacher.page.php
@@ -7,7 +7,9 @@ session_start();
 try {
     $search = $_GET['searchTeacher'] ?? '';
     $teacher = new Teacher();
+
     $listTeachers = $teacher->listTeacher($search);
+    $countTeachers = $teacher->countTeachers($search);
 
     $optionOfSearch = array();
     foreach ($listTeachers as $row) {
@@ -116,8 +118,7 @@ try {
 
     <!-- Contador de professores ⬇️ -->
     <p>
-        Total
-        <?php echo count($listTeachers); ?>
+        <?php echo $countTeachers ?>
     </p>
 
     <!-- Lista de professores ⬇️ -->


### PR DESCRIPTION
Devido o modo de implementação da paginação, houve conflito com os contadores existentes. O ajuste feito faz com que os contadores fiquem separados, motrando o total da página e quando há alguma pesquisa, mostra o contador filtrando somente os resultados da pesquisa. ⚠️ **Ajustes feitos em professores e módulos**

💻 Link de acesso:
<a href="http://localhost/project/private/adm/pages/register/registration%20panel/registration-panel.php">Painel de acesso</a>