### PR TITLE
Bug update etecs

### DIFF
--- a/classes/schools/School.class.php
+++ b/classes/schools/School.class.php
@@ -526,13 +526,9 @@ class School extends Social
                 $queryValues = [];
                 $idTeacherToInsert = [];
 
-                for ($i = 0; $i < count($arrayToInsert); $i++) {
-                    $item = $arrayToInsert[$i];
-
-                    if ($item) {
-                        array_push($queryValues, '(NOW(), ?, ?)');
-                        array_push($idTeacherToInsert, $item);
-                    }
+                foreach ($arrayToInsert as $row => $value) {
+                    array_push($queryValues, '(NOW(), ?, ?)');
+                    array_push($idTeacherToInsert, $value);
                 }
 
                 $insertTeacher = $connection->prepare(


### PR DESCRIPTION
Estávamos com um bug 🐛  na hora de fazer **update** nos cursos, quando iria adicionar uma etec ao `array`. Esse bug foi solucionado mudando o laço de repetição, antes usando o `for` para ler um array, agora foi mudado para um `foreach` que percorre um objeto. 👾 