### PR TITLE
Fix do Texto no Modal das ETECs

### DIFF
--- a/private/adm/pages/register/register-school/list-school.page.php
+++ b/private/adm/pages/register/register-school/list-school.page.php
@@ -418,7 +418,7 @@ try {
                                 <div id="body-modal-have-account-2">
                                     <br>
                                     <label class="normal-14-medium-p about-school-label">Sobre</label>
-                                    <div id="about-school" class="whitney-16-medium-text white-title about-school-text" style="width: fit-content;"></div>
+                                    <div id="about-school" class="whitney-16-medium-text white-title about-school-text"></div>
 
                                 </div>
 

--- a/private/style/modal-about.style.css
+++ b/private/style/modal-about.style.css
@@ -150,6 +150,7 @@
 
 .about-school-text{
     word-wrap: break-word;
+    width: 100%;
     /* word-break: break-all; */
 }
 


### PR DESCRIPTION
PR aberta pois o texto **Sobre** do modal das ETECs estava dando overflow, agora foi melhorado para o certo

### [Confira!](http://localhost/project/private/adm/pages/register/register-school/list-school.page.php)