### PR TITLE
Etec sem conta

### DIFF
--- a/classes/schools/Course.class.php
+++ b/classes/schools/Course.class.php
@@ -454,7 +454,6 @@ class Course
                                         INNER JOIN schools s
                                         ON s.id = sc.school_id
                                         WHERE sc.course_id = $idCourse)
-                                        AND s.have_account = 'Com conta'
                                         ");
 
         $stmt->execute();

--- a/classes/schools/School.class.php
+++ b/classes/schools/School.class.php
@@ -809,8 +809,7 @@ class School extends Social
         $connection = Connection::connection();
 
         try {
-            $stmt = $connection->prepare("SELECT id, name FROM schools
-                                            WHERE have_account = 'Com conta'");
+            $stmt = $connection->prepare("SELECT id, name FROM schools");
             $stmt->execute();
 
             $result = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
# Etec sem conta
O intuito de não ter uma etec com conta é para que ela apareça nos cadastros, mas que não tenha um perfil quando for pesquisada pelo aluno.

### O que foi implementado:
- Quando cadastra ou faz um update do curso a etec aparece no select.
- Quando entra no modal de cursos, a etec aparece na lista.
- Ao aluno se cadastrar, a etec irá aparecer como opção.
- Se pesquisar por etecs dentro do heelp, ela não estará na lista.

##
### <a href="http://localhost/project/views/pages/login/login-page.php">Link de acesso</a>